### PR TITLE
検索結果画面の訂正

### DIFF
--- a/app/views/dogs/search.html.erb
+++ b/app/views/dogs/search.html.erb
@@ -8,7 +8,9 @@
         <li class='search-list'>
           <%= link_to dog_path(result.id) do %>
             <div class='dog-img-content'>
-              <%= image_tag result.images[0], class: "dog-img" %>
+              <% result.images.each do |image| %>
+                <%= image_tag image, class: "dog-img" %>
+              <% end %>
             </div>
           <% end %>
           <div class='dog-info'>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,16 @@
 		});
 	</script>
 
+	<script>
+		$(function(){
+			$('.dog-img-content').bxSlider({
+        auto: true,
+				mode: 'fade',
+				speed: "1000"
+			});
+		});
+	</script>
+
   </head>
 
   <body>


### PR DESCRIPTION
開発環境では問題無かったが、 herokuでactionview::template::error (nil location provided. can't build uri.)
と出てしまう対策。
検索結果画面では、一枚目のみの画像のみ表示から、bxsliderに切り替えた